### PR TITLE
Read full json message from socket in i3ipc.aio.connection

### DIFF
--- a/i3ipc/aio/connection.py
+++ b/i3ipc/aio/connection.py
@@ -304,7 +304,7 @@ class Connection:
       buf = bytearray(size)
       mem = memoryview(buf)
       sock = self._sub_socket
-      while len(buf):
+      while len(mem):
         if not (rsize := sock.recv_into(mem)):
           return b''
         mem = mem[rsize:]

--- a/i3ipc/aio/connection.py
+++ b/i3ipc/aio/connection.py
@@ -302,12 +302,13 @@ class Connection:
 
     def _recv(self, size):
       buf = bytearray(size)
-      off = 0
+      mem = memoryview(buf)
       sock = self._sub_socket
-      while off < size:
-        if not (rsize := sock.recv_into(memoryview(buf)[off:])):
+      while len(buf):
+        if not (rsize := sock.recv_into(mem)):
           return b''
-        off += rsize
+        mem = mem[rsize:]
+      mem.release()
       return buf
 
     def _read_message(self):


### PR DESCRIPTION
Python socket.recv takes a _maximum_length -- but may return a shorter message depending on detail of the socket state. Replaced with a socket.recv_into loop that read the entire json message.